### PR TITLE
chore(deps): upgrade deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "dependencies": {
         "@radix-ui/react-icons": "^1.3.0",
-        "@types/node": "^20.12.12",
+        "@types/node": "^20.12.13",
         "@wix/ecom": "^1.0.444",
-        "@wix/redirects": "^1.0.46",
-        "@wix/sdk": "^1.9.3",
+        "@wix/redirects": "^1.0.47",
+        "@wix/sdk": "^1.9.6",
         "@wix/stores": "^1.0.121",
         "classnames": "^2.5.1",
         "js-cookie": "^3.0.5",
@@ -24,7 +24,7 @@
       "devDependencies": {
         "@faker-js/faker": "^8.4.1",
         "@types/js-cookie": "^3.0.6",
-        "@types/react": "^18.3.2",
+        "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.0",
         "@wixc3/react-board": "^2.5.0",
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.6.tgz",
+      "integrity": "sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -840,174 +840,6 @@
         }
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.6.1.tgz",
-      "integrity": "sha512-0WQ0ouLejaUCRsL93GD4uft3rOmB8qoQMU05Kb8CmMtMBe7XUDLAltxVZI1q6byNqEtU7N1ZX1Vw5lIpgulLQA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.6.1.tgz",
-      "integrity": "sha512-1TKm25Rn20vr5aTGGZqo6E4mzPicCUD79k17EgTLAsXc1zysyi4xXKACfUbwyANEPAEIxkzwue6JZ+stYzWUTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.6.1.tgz",
-      "integrity": "sha512-cEXJQY/ZqMACb+nxzDeX9IPLAg7S94xouJJCNVE5BJM8JUEP4HeTF+ti3cmxWeSJo+5D+o8Tc0UAWUkfENdeyw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.6.1.tgz",
-      "integrity": "sha512-LoSU9Xu56isrkV2jLldcKspJ7sSXmZWkAxg7sW/RfF7GS4F5/v4EiqKSMCFbZtDu2Nc1gxxFdQdKwkKS4rwxNg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.6.1.tgz",
-      "integrity": "sha512-EfI3hzYAy5vFNDqpXsNxXcgRDcFHUWSx5nnRSCKwXuQlI5J9dD84g2Usw81n3FLBNsGCegKGwwTVsSKK9cooSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.6.1.tgz",
-      "integrity": "sha512-9lhc4UZstsegbNLhH0Zu6TqvDfmhGzuCWtcTFXY10VjLLUe4Mr0Ye2L3rrtHaDd/J5+tFMEuo5LTCSCMXWfUKw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.6.1.tgz",
-      "integrity": "sha512-FfoOK1yP5ksX3wwZ4Zk1NgyGHZyuRhf99j64I5oEmirV8EFT7+OhUZEnP+x17lcP/QHJNWGsoJwrz4PJ9fBEXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.6.1.tgz",
-      "integrity": "sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.6.1.tgz",
-      "integrity": "sha512-RkJVNVRM+piYy87HrKmhbexCHg3A6Z6MU0W9GHnJwBQNBeyhCJG9KDce4SAMdicQnpURggSvtbGo9xAWOfSvIQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.6.1.tgz",
-      "integrity": "sha512-v2FVT6xfnnmTe3W9bJXl6r5KwJglMK/iRlkKiIFfO6ysKs0rDgz7Cwwf3tjldxQUrHL9INT/1r4VA0n9L/F1vQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.6.1.tgz",
-      "integrity": "sha512-YEeOjxRyEjqcWphH9dyLbzgkF8wZSKAKUkldRY6dgNR5oKs2LZazqGB41cWJ4Iqqcy9/zqYgmzBkRoVz3Q9MLw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.6.1.tgz",
-      "integrity": "sha512-0zfTlFAIhgz8V2G8STq8toAjsYYA6eci1hnXuyOTUFnymrtJwnS6uGKiv3v5UrPZkBlamLvrLV2iiaeqCKzb0A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.6.1.tgz",
@@ -1280,9 +1112,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "version": "20.12.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.13.tgz",
+      "integrity": "sha512-gBGeanV41c1L171rR7wjbMiEpEI/l5XFQdLLfhr/REwpgDy/4U8y89+i8kRiLzDyZdOkXh+cRaTetUnCYutoXA==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1294,9 +1126,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.2.tgz",
-      "integrity": "sha512-Btgg89dAnqD4vV7R3hlwOxgqobUQKgx3MmrQRi0yYbs/P0ym8XozIAlkqVilPqHQwXs4e9Tf63rrCgl58BcO4w==",
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
+      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -1407,35 +1239,67 @@
       }
     },
     "node_modules/@wix/image-kit": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.67.0.tgz",
-      "integrity": "sha512-bHsJoYuefFJ9l/x1tIobxw/leEN/X0W81FYNTQKx3SMQOdFC6bOC9JVFnR3ByoN3kNHt69brDcg3hhiWfVbrFg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@wix/image-kit/-/image-kit-1.68.0.tgz",
+      "integrity": "sha512-mskKXNAikrboQj6EugrqPTCwIxYKDuxxAEWQNcyJ7aIqhRCg5M2wgsxKECGqtOzvZ77/PTyzPWrs5g79W/fjQA==",
       "dependencies": {
-        "@babel/runtime": "^7.24.5",
+        "@babel/runtime": "^7.24.6",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@wix/metro-public-utils": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@wix/metro-public-utils/-/metro-public-utils-1.0.13.tgz",
-      "integrity": "sha512-8kCrXArhJOkOcYhjZ469+K75rCmpQGEVrOvIPvs/xNMLE/pvjN22XbbCo9Wng0PElvi65mdP8DGVmFXrS15jXA==",
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@wix/metro-public-utils/-/metro-public-utils-1.0.29.tgz",
+      "integrity": "sha512-jcII/Xuj8Sc2Q9VNtY6WxadkFP/d0Nq/w+HseuFQCq3jzSCBNOJVEiAqB5kXqxlglwMzgD8qJ8He/FcdYKi2Qg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0"
       }
     },
     "node_modules/@wix/metro-runtime": {
-      "version": "1.1588.0",
-      "resolved": "https://registry.npmjs.org/@wix/metro-runtime/-/metro-runtime-1.1588.0.tgz",
-      "integrity": "sha512-PWfjAqeMJ1R1mSVLyVzPdxahOoDphjFcOTZI1N1EC+kbL1imLYLx/OKYMyM1d344FJpW5CTM4LBixaxs3ftBHQ==",
+      "version": "1.1697.0",
+      "resolved": "https://registry.npmjs.org/@wix/metro-runtime/-/metro-runtime-1.1697.0.tgz",
+      "integrity": "sha512-2fwPazhJuClLgQsgmlI3Kk6wFmZYaMMPHFNmx2cUJAkLG/37wOSJmgxr2yfjW5kSkv/ay3z78vJF9D/XsL5eVg==",
       "dependencies": {
-        "@wix/metro-public-utils": "1.0.13",
-        "@wix/motion-edm-autogen-p13n": "1.0.35",
-        "@wix/motion-edm-autogen-transformations": "1.35.0",
-        "@wix/motion-edm-autogen-transformations-core": "1.32.0",
+        "@wix/metro-public-utils": "1.0.29",
+        "@wix/motion-edm-autogen-p13n": "1.0.64",
+        "@wix/motion-edm-autogen-transformations": "1.52.0",
+        "@wix/motion-edm-autogen-transformations-core": "1.48.0",
+        "js-base64": "^3.7.7",
         "lodash": "^4.17.21",
         "long": "^4.0.0",
         "querystring": "^0.2.1"
       }
+    },
+    "node_modules/@wix/metro-runtime/node_modules/@wix/motion-edm-autogen-common": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-common/-/motion-edm-autogen-common-1.44.0.tgz",
+      "integrity": "sha512-L7mgVg/LKEfmUxtfGw+DJ53snaG0sOauEW6WX7kEloxlbsCEoFBBkiPlDQIxfdjWh0Ogo/UL4UZB16oztINmHg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@wix/motion-edm-autogen-types": "1.0.32",
+        "lodash": "~4.17.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@wix/metro-runtime/node_modules/@wix/motion-edm-autogen-transformations-core": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-transformations-core/-/motion-edm-autogen-transformations-core-1.48.0.tgz",
+      "integrity": "sha512-v+DUizIZWoGx0k/RmrmBg45+uaQ48pPwlS3Aiqoj/7X4R7FqMrcbwwlj7hZRRSUV5fbmMYBsHJYU60GZMQ5qOg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@rushstack/eslint-patch": "^1.1.0",
+        "@wix/motion-edm-autogen-common": "1.44.0",
+        "constant-case": "~3.0.0",
+        "deep-for-each": "~3.0.0",
+        "jsonpath-plus": "~5.1.0",
+        "lodash": "~4.17.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@wix/metro-runtime/node_modules/@wix/motion-edm-autogen-types": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-types/-/motion-edm-autogen-types-1.0.32.tgz",
+      "integrity": "sha512-ZamDS3PVrRx4/njcaVo2o34DPTqlVsnJgmEFrASf6bvvQ03orgemjmW9wbThY9PbsciZ7WKblyDiTDgMy7BhJg=="
     },
     "node_modules/@wix/motion-edm-autogen-common": {
       "version": "1.28.0",
@@ -1449,14 +1313,19 @@
       }
     },
     "node_modules/@wix/motion-edm-autogen-p13n": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-p13n/-/motion-edm-autogen-p13n-1.0.35.tgz",
-      "integrity": "sha512-1y14WrGalsNXpVzrAUrOSID9NHgcbXzsXPWox8aCj4zox0bJ1juxdp7TxfB0cMUukOfxr+1rItAj0YX+ygE4tA==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-p13n/-/motion-edm-autogen-p13n-1.0.64.tgz",
+      "integrity": "sha512-w3H5VuvwdqYNYBPd30DI/d3Hd3ff565kFLtWoLqKJY0Zaw77MjWn0y6TNC6EV1Owz3rg4+DvIW7xQRdsEluQQg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "@wix/motion-edm-autogen-types": "1.0.16",
+        "@wix/motion-edm-autogen-types": "1.0.32",
         "lodash": "~4.17.0"
       }
+    },
+    "node_modules/@wix/motion-edm-autogen-p13n/node_modules/@wix/motion-edm-autogen-types": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-types/-/motion-edm-autogen-types-1.0.32.tgz",
+      "integrity": "sha512-ZamDS3PVrRx4/njcaVo2o34DPTqlVsnJgmEFrASf6bvvQ03orgemjmW9wbThY9PbsciZ7WKblyDiTDgMy7BhJg=="
     },
     "node_modules/@wix/motion-edm-autogen-query-wrapper": {
       "version": "1.0.51",
@@ -1473,14 +1342,14 @@
       }
     },
     "node_modules/@wix/motion-edm-autogen-transformations": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-transformations/-/motion-edm-autogen-transformations-1.35.0.tgz",
-      "integrity": "sha512-Cukj0C8x1ESgDmmrcLuhy0ptcfnh1g63dKFTiR92W5BceAz3OImTuKuRlHmOBIhQ4n8shXarYIbC4Gby0TTJBA==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-transformations/-/motion-edm-autogen-transformations-1.52.0.tgz",
+      "integrity": "sha512-mTufyan9CE0S4n9QxNhtuKkIxwhVNZnU+rjJizLEk9Qev6kX8m0MP8H63G0Tt3R2jwdq6rd24fBLZ5RljfPRyg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@rushstack/eslint-patch": "^1.1.0",
-        "@wix/motion-edm-autogen-common": "1.28.0",
-        "@wix/motion-edm-autogen-transformations-core": "1.32.0",
+        "@wix/motion-edm-autogen-common": "1.44.0",
+        "@wix/motion-edm-autogen-transformations-core": "1.48.0",
         "constant-case": "~3.0.0",
         "deep-for-each": "~3.0.0",
         "http-status-codes": "^2.0.0",
@@ -1505,40 +1374,71 @@
         "tslib": "^2.0.0"
       }
     },
+    "node_modules/@wix/motion-edm-autogen-transformations/node_modules/@wix/motion-edm-autogen-common": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-common/-/motion-edm-autogen-common-1.44.0.tgz",
+      "integrity": "sha512-L7mgVg/LKEfmUxtfGw+DJ53snaG0sOauEW6WX7kEloxlbsCEoFBBkiPlDQIxfdjWh0Ogo/UL4UZB16oztINmHg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@wix/motion-edm-autogen-types": "1.0.32",
+        "lodash": "~4.17.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@wix/motion-edm-autogen-transformations/node_modules/@wix/motion-edm-autogen-transformations-core": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-transformations-core/-/motion-edm-autogen-transformations-core-1.48.0.tgz",
+      "integrity": "sha512-v+DUizIZWoGx0k/RmrmBg45+uaQ48pPwlS3Aiqoj/7X4R7FqMrcbwwlj7hZRRSUV5fbmMYBsHJYU60GZMQ5qOg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@rushstack/eslint-patch": "^1.1.0",
+        "@wix/motion-edm-autogen-common": "1.44.0",
+        "constant-case": "~3.0.0",
+        "deep-for-each": "~3.0.0",
+        "jsonpath-plus": "~5.1.0",
+        "lodash": "~4.17.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/@wix/motion-edm-autogen-transformations/node_modules/@wix/motion-edm-autogen-types": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-types/-/motion-edm-autogen-types-1.0.32.tgz",
+      "integrity": "sha512-ZamDS3PVrRx4/njcaVo2o34DPTqlVsnJgmEFrASf6bvvQ03orgemjmW9wbThY9PbsciZ7WKblyDiTDgMy7BhJg=="
+    },
     "node_modules/@wix/motion-edm-autogen-types": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/@wix/motion-edm-autogen-types/-/motion-edm-autogen-types-1.0.16.tgz",
       "integrity": "sha512-DroHUs1tMilDxGKnMQpqo3KMKFKlymvVeQmhLuoz3xdTOVkUp/MhKHULLEdNb+O6NqrIy0lklVX+QCf/m+Sbuw=="
     },
     "node_modules/@wix/redirects": {
-      "version": "1.0.46",
-      "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.46.tgz",
-      "integrity": "sha512-I67W4z1nBH/XUfWpJubx52bD10VIo5kATTTufqaeBwzIZ2zw9UiQf8nBaybuDI9zSKoMTyqF6N042IY8A26eRw==",
+      "version": "1.0.47",
+      "resolved": "https://registry.npmjs.org/@wix/redirects/-/redirects-1.0.47.tgz",
+      "integrity": "sha512-YgbhhobMQEU9rYUiTe9lFhdVQwnOy6p5wcefYw5ZTfQ9iJzjvshOTrnebtk6aSxU6WdJK9C37m4jJX93oDEXxA==",
       "dependencies": {
-        "@wix/redirects_redirects": "1.0.16"
+        "@wix/redirects_redirects": "1.0.17"
       }
     },
     "node_modules/@wix/redirects_redirects": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@wix/redirects_redirects/-/redirects_redirects-1.0.16.tgz",
-      "integrity": "sha512-yxcPb4IKFT9dSFGS2yjx0pAHUPq8FcAajMCJ+wZVhaKtTEc/Ued0T1Y3jUbidM6VkGupdTodditAd9135cOBxg==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@wix/redirects_redirects/-/redirects_redirects-1.0.17.tgz",
+      "integrity": "sha512-s/hrfTL/uHXQE0SkT15m671AroKDSFLnl1b71hMLeN2VfZQZdQbYie+U+SweueHVjgvBsK9P2y2ZmTMPJPhB5w==",
       "dependencies": {
-        "@wix/metro-runtime": "^1.1528.0",
+        "@wix/metro-runtime": "^1.1696.0",
         "@wix/motion-edm-autogen-query-wrapper": "^1.0.37",
         "@wix/sdk-runtime": "^0.2.10",
         "@wix/sdk-types": "^1.6.2"
       }
     },
     "node_modules/@wix/sdk": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.9.3.tgz",
-      "integrity": "sha512-B/eoNK76w8wnBRFxgdkYxYyq+ff7K3+q5GCG47AfpK2XLamxYY5f+CZBU/Vv+7Re/MCwcxe08T8hzSl+eCDiYw==",
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/@wix/sdk/-/sdk-1.9.6.tgz",
+      "integrity": "sha512-rDkkWnDYxkUO6YQ0QLcgk/KfTVXiaaeCsgIA+YzMVGd4lfrS9DjDsXYeUXn9ZIJg0bzYWAPfhcjQWEjWwoc0Aw==",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
         "@wix/identity": "^1.0.78",
-        "@wix/image-kit": "^1.67.0",
+        "@wix/image-kit": "^1.68.0",
         "@wix/redirects": "^1.0.41",
-        "@wix/sdk-types": "^1.6.3",
+        "@wix/sdk-types": "^1.7.1",
         "crypto-js": "^4.2.0",
         "jose": "^5.2.1",
         "pkce-challenge": "^3.1.0",
@@ -1558,9 +1458,9 @@
       }
     },
     "node_modules/@wix/sdk-types": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.6.3.tgz",
-      "integrity": "sha512-kz+T8XljRvwgjyWajrFuvjO8vZx8njyzYOrDPk1ONOlENn4dACNEk/QWMXULJZbTqKZeh0/zhS7o4S5AM5DREA=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@wix/sdk-types/-/sdk-types-1.7.1.tgz",
+      "integrity": "sha512-XHGYflxjbY1kNZTNcpUWWBokVaMjskeLMi/8+CqLDmNR6OCUA8R0HoeedC6MI+m6YDfcaymlMWzMaWeJVdxwOQ=="
     },
     "node_modules/@wix/stores": {
       "version": "1.0.121",
@@ -2114,6 +2014,11 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
+    },
     "node_modules/js-cookie": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
@@ -2469,36 +2374,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/rollup": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.6.1.tgz",
-      "integrity": "sha512-jZHaZotEHQaHLgKr8JnQiDT1rmatjgKlMekyksz+yk9jt/8z9quNjnKNRoaM0wd9DC2QKXjmWWuDYtM3jfF8pQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.6.1",
-        "@rollup/rollup-android-arm64": "4.6.1",
-        "@rollup/rollup-darwin-arm64": "4.6.1",
-        "@rollup/rollup-darwin-x64": "4.6.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.6.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.6.1",
-        "@rollup/rollup-linux-arm64-musl": "4.6.1",
-        "@rollup/rollup-linux-x64-gnu": "4.6.1",
-        "@rollup/rollup-linux-x64-musl": "4.6.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.6.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.6.1",
-        "@rollup/rollup-win32-x64-msvc": "4.6.1",
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/sass": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
-    "@types/node": "^20.12.12",
+    "@types/node": "^20.12.13",
     "@wix/ecom": "^1.0.444",
-    "@wix/redirects": "^1.0.46",
-    "@wix/sdk": "^1.9.3",
+    "@wix/redirects": "^1.0.47",
+    "@wix/sdk": "^1.9.6",
     "@wix/stores": "^1.0.121",
     "classnames": "^2.5.1",
     "js-cookie": "^3.0.5",
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
     "@types/js-cookie": "^3.0.6",
-    "@types/react": "^18.3.2",
+    "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
     "@wixc3/react-board": "^2.5.0",


### PR DESCRIPTION

## Dependency Updates

### Minor and Patch Updates:

@types/node ^20.12.12 -> ^20.12.13
@wix/redirects ^1.0.46 -> ^1.0.47
@wix/sdk ^1.9.3 -> ^1.9.6
@types/react ^18.3.2 -> ^18.3.3

### Major Updates (Reverted):

vite ^4.5.2 -> ^5.2.12
vite-plugin-svgr ^3.3.0 -> ^4.2.0

### Skipped Updates:

@wix/ecom ^1.0.444 -> ^1.0.571
@wix/stores ^1.0.121 -> ^1.0.150

Note: The packages @wix/ecom and @wix/stores were skipped because they are breaking in Codux.